### PR TITLE
Reduce size of variadic-test result data

### DIFF
--- a/variadic-test.py
+++ b/variadic-test.py
@@ -336,6 +336,11 @@ def main():
       for config, _ in configs:
         check_output(data['printf'][config], data[method][config])
 
+  for method, _ in methods:
+    for config, _ in configs:
+      for result in data[method][config]:
+        del result['output']
+
   with open('variadic-test.pkl', 'wb') as file:
     pickle.dump(data, file)
 


### PR DESCRIPTION
I forgot to push this earlier. It's just a small tweak for variadic-test.
The formatted string output can be a few MB in size, but doesn't need to be saved with the performance data (which is only a few KB).